### PR TITLE
Adding information on how to dump firmware files in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@
 ## Information:
 
 shadPS4 can load some PlayStation 4 firmware files, these must be dumped from your legally owned PlayStation 4 console.\
-The following firmware modules are supported and must be placed in shadPS4's `sys_modules` folder.
+The following firmware modules are supported and must be placed in shadPS4's `sys_modules` folder.\
+For more information on how to dump your firmware files, you can check the [shadPS4 wiki](https://github.com/shadps4-emu/shadPS4/wiki/I.-Quick-start-%5BUsers%5D#4-dumping-firmware-modules).
 
 <div align="center">
 


### PR DESCRIPTION
Completely unrelated to this PR but the second branch on this repo for the new release should probably be deleted (this is my only way of communicating for now so I'm using it).